### PR TITLE
Changed the reset implementation and fixed some sonar warnings

### DIFF
--- a/src/main/java/uk/co/probablyfine/dirty/Store.java
+++ b/src/main/java/uk/co/probablyfine/dirty/Store.java
@@ -129,10 +129,10 @@ public class Store<T> {
 
   public void reset() {
     this.size = 0;
-    for (int i = 1; i < partitions.size(); i++) {
-      partitions.remove(i);
-    }
-    this.partitions.get(0).putInt(0, 0);
+    MappedByteBuffer head = partitions.get(0);
+    partitions.clear();
+    partitions.add(head);
+    head.putInt(0, 0);
   }
 
   public interface WithFile<T> {

--- a/src/main/java/uk/co/probablyfine/dirty/Store.java
+++ b/src/main/java/uk/co/probablyfine/dirty/Store.java
@@ -93,9 +93,10 @@ public class Store<T> {
 
   public Stream<T> reverse() {
     Stream.Builder<T> builder = Stream.builder();
-
-    for(int index = (this.size-1); index >= 0; index--) {
+    int index = this.size - 1;
+    while(index >= 0) {
       builder.add(extractEntry(index));
+      index--;
     }
 
     return builder.build();

--- a/src/main/java/uk/co/probablyfine/dirty/utils/Classes.java
+++ b/src/main/java/uk/co/probablyfine/dirty/utils/Classes.java
@@ -7,6 +7,10 @@ import static java.util.Arrays.asList;
 
 public class Classes {
 
+  private Classes() {
+    //Utility classes have no public constructor
+  }
+
   public static Stream<Field> primitiveFields(Class<?> klass) {
     return asList(klass.getDeclaredFields())
         .stream()

--- a/src/main/java/uk/co/probablyfine/dirty/utils/Exceptions.java
+++ b/src/main/java/uk/co/probablyfine/dirty/utils/Exceptions.java
@@ -2,6 +2,11 @@ package uk.co.probablyfine.dirty.utils;
 
 public class Exceptions {
 
+  public static class StoreException extends RuntimeException {
+      public StoreException(Throwable cause) {
+          super(cause);
+      }
+  }
   public interface ExceptionalSupplier<T,E extends Exception> {
     public T get() throws E;
   }
@@ -14,7 +19,7 @@ public class Exceptions {
     try {
       return supplier.get();
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new StoreException(e);
     }
   }
 
@@ -22,7 +27,7 @@ public class Exceptions {
     try {
       supplier.call();
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new StoreException(e);
     }
   }
 }

--- a/src/main/java/uk/co/probablyfine/dirty/utils/Nio.java
+++ b/src/main/java/uk/co/probablyfine/dirty/utils/Nio.java
@@ -8,6 +8,7 @@ import java.nio.channels.FileChannel;
 import static uk.co.probablyfine.dirty.utils.Exceptions.unchecked;
 
 public class Nio {
+    private Nio() {} //Utility classes have no public constructor
 
   public static FileChannel fileChannel(String path) {
     File file = new File(path);
@@ -15,9 +16,7 @@ public class Nio {
   }
 
   public static MappedByteBuffer mapFile(FileChannel fileChannel, int initialPosition, int size) {
-    return unchecked(() -> {
-      return fileChannel.map(FileChannel.MapMode.READ_WRITE, initialPosition, size);
-    });
+    return unchecked(() -> fileChannel.map(FileChannel.MapMode.READ_WRITE, initialPosition, size));
   }
 
 }

--- a/src/main/java/uk/co/probablyfine/dirty/utils/Nio.java
+++ b/src/main/java/uk/co/probablyfine/dirty/utils/Nio.java
@@ -8,7 +8,9 @@ import java.nio.channels.FileChannel;
 import static uk.co.probablyfine.dirty.utils.Exceptions.unchecked;
 
 public class Nio {
-    private Nio() {} //Utility classes have no public constructor
+  private Nio() {
+    //Utility classes have no public constructor
+  }
 
   public static FileChannel fileChannel(String path) {
     File file = new File(path);

--- a/src/main/java/uk/co/probablyfine/dirty/utils/Types.java
+++ b/src/main/java/uk/co/probablyfine/dirty/utils/Types.java
@@ -2,7 +2,6 @@ package uk.co.probablyfine.dirty.utils;
 
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 public enum Types {

--- a/src/main/java/uk/co/probablyfine/dirty/utils/Types.java
+++ b/src/main/java/uk/co/probablyfine/dirty/utils/Types.java
@@ -17,8 +17,8 @@ public enum Types {
 
   private final Class<?> type;
   private final int size;
-  private TriConsumer<ByteBuffer, Integer, Object> writeField;
-  private BiFunction<ByteBuffer, Integer, Object> readField;
+  private transient TriConsumer<ByteBuffer, Integer, Object> writeField;
+  private transient BiFunction<ByteBuffer, Integer, Object> readField;
 
   Types(Class<?> type, int size, TriConsumer<ByteBuffer, Integer, Object> writeField, BiFunction<ByteBuffer, Integer, Object> readField) {
     this.type = type;

--- a/src/test/java/uk/co/probablyfine/dirty/utils/ExceptionsTest.java
+++ b/src/test/java/uk/co/probablyfine/dirty/utils/ExceptionsTest.java
@@ -1,0 +1,24 @@
+package uk.co.probablyfine.dirty.utils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.isA;
+
+public class ExceptionsTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+  @Test
+  public void causeAndNestedCause() throws Exception {
+    expectedException.expect(Exceptions.StoreException.class);
+    expectedException.expectCause(isA(ArithmeticException.class));
+    Exceptions.unchecked(()-> foo());
+
+  }
+
+  private void foo() {
+    int a = 1/0;
+  }
+}


### PR DESCRIPTION
Hi
You've got a nice set of functionality in this tool and very nice implementation. I've just added some icing to the cake.
- reset was removing elements one by one and forcing the underlying array to be copied over and over. I've changed reset for clarity and brevity and potentially performance. 
- Sonar had some minor issues that was fixed too (unused imports, public constructor, etc. check the individual commits)

I'm happy to change the PR on your review
Cheers,
Gunnar
